### PR TITLE
Implements CLSModel, regularizers and solver

### DIFF
--- a/src/general-constrained-model/CLS-model.jl
+++ b/src/general-constrained-model/CLS-model.jl
@@ -1,0 +1,95 @@
+"""
+    Structure for Constrained Least Squares model to solve:
+
+        min_{x in Constraint} (1/2)|| Ax - b ||^2
+
+    With fields:
+
+        - `A` is the matrix of constraints
+        - `b` is the right-hand side
+        - `λ` is the regularization parameter
+        - `C` is a positive definite scaling matrix
+        - `w` is an n-buffer for the Hessian-vector product 
+        - `reg` is the regularizer function object
+        - `bNrm` is the norm of the right-hand side
+        - `name` is the name of the problem
+        - `Constraint` is the constraint set, must be in enum Constraints
+"""
+@enum Constraints simplex oneBall infBall
+
+struct CLSModel{T<:AbstractFloat, M<:AbstractMatrix{T}, CT, V<:AbstractVector{T}} <: AbstractNLPModel{T, V}
+    A::M
+    b::V
+    λ::T
+    C::CT
+    w::V
+    reg
+    bNrm::T
+    scale::T
+    name::String
+    meta::NLPModelMeta{T, V}
+    counters::Counters
+    Constraint::Constraints
+end
+
+function CLSModel(A::AbstractMatrix{T}, b::AbstractVector{T}; λ::T=√eps(T), C=I, name::String="", Constraint::Constraints=simplex) where T<:AbstractFloat
+    n = size(A, 2)
+    w = zeros(T, n)
+    reg = nothing
+    cls = CLSModel{T, typeof(A), typeof(C), typeof(b)}(
+        A,
+        b,
+        λ,
+        C,
+        w,
+        reg,
+        norm(b),
+        one(T),
+        name,
+        NLPModelMeta(size(A, 1), name="CLS Model"),
+        Counters(),
+        Constraint
+    )
+    set_constraint!(cls, Constraint)
+    return cls
+end
+
+function Base.show(io::IO, cls::CLSModel)
+    println(io, "Constrained least squares" * (cls.name == "" ? "" : ": " * cls.name))
+    println(io, @sprintf("   m = %5d  bNrm = %7.1e", size(cls.A, 1), cls.bNrm))
+    println(io, @sprintf("   n = %5d  λ    = %7.1e", size(cls.A, 2), cls.λ))
+    println(io, @sprintf("       %5s  τ    = %7.1e", " ", cls.scale))
+end
+
+function regularize!(cls::CLSModel{T}, λ::T) where T
+    cls.λ = λ
+    return cls
+end
+
+function scale!(cls::CLSModel{T}, scale::T) where T
+    cls.scale = scale
+    return cls
+end
+
+function reset!(cls::CLSModel)
+    for f in fieldnames(Counters)
+        setfield!(cls.counters, f, 0)
+    end
+    return cls
+end
+
+function set_constraint!(cls::CLSModel, set::Constraints)
+    cls.Constraint = set
+    n = size(cls.A, 2)
+    T = eltype(cls.A)
+    if set == simplex
+        cls.reg = LogSumExp(zeros(T, n))
+    elseif set == oneBall
+        cls.reg = LogSumCosh(zeros(T, n), zeros(T, n), zeros(T, n))
+    elseif set == infBall
+        cls.reg = SumLogCosh(zeros(T, n))
+    else
+        error("Unknown constraint set")
+    end
+    return cls
+end

--- a/src/general-constrained-model/regularizers/logsumcosh.jl
+++ b/src/general-constrained-model/regularizers/logsumcosh.jl
@@ -1,0 +1,56 @@
+"""
+    Regularizer used to constrain domain to one-norm ball
+
+    f(x) = log(2∑cosh(x_i))
+"""
+struct LogSumCosh{T<:AbstractFloat, V<:AbstractVector{T}} <: Regularizer
+    g::V      # buffer for gradient
+    e_p::V    # buffer for positive exponentials
+    e_n::V    # buffer for negative exponentials
+    s::T      # sum of exponentials
+end
+
+"""
+    Evaluate logΣcosh, its gradient, and Hessian at `p`:
+
+        f = obj!(lsc, p)
+
+    where `p` is a vector of length `n` and `lsc` is a `LogSumCosh` object.
+
+    This implementation safeguards against numerical under/overflow.
+"""
+function obj!(lsc::LogSumCosh, p)
+    @unpack g, e_p, e_n = lsc
+    maxval = maximum(abs.(p))
+
+    @. e_p = exp(p - maxval)
+    @. e_n = exp(-p - maxval)
+    s_p = sum(e_p)
+    s_n = sum(e_n)
+    s = s_p + s_n
+    lsc.s = s
+
+    f = maxval + log(s)
+    @. g = (e_p - e_n) / s
+    return f
+end
+
+"""
+    Get the gradient of logΣcosh at the point `p` where
+    the `lsc` objective was last evaluated:
+
+        g = grad(lsc)
+"""
+grad(lsc::LogSumCosh) = lsc.g
+
+"""
+    Get the Hessian of logΣcosh at the point `p` where
+    the `lsc` objective was last evaluated:
+
+        H = hess(lsc)
+"""
+function hess(lsc::LogSumCosh)
+    @unpack g, e_p, e_n, s = lsc
+    h = ((e_p .+ e_n) ./ (2s)) .- (g .^ 2)
+    return Diagonal(h) - g * g'
+end

--- a/src/general-constrained-model/regularizers/logsumexp.jl
+++ b/src/general-constrained-model/regularizers/logsumexp.jl
@@ -1,0 +1,58 @@
+"""
+    Regularizer used to constrain domain to infty-norm ball
+
+    f(x) = log(∑exp(x_i))
+"""
+struct LogSumExp{T<:AbstractFloat, V1<:AbstractVector{T}, V2<:AbstractVector{T}} <: Regularizer
+    g::V1 # buffer for gradient
+end
+
+"""
+    Evaluate logΣexp, its gradient, and Hessian at `p`:
+
+        f = obj!(lse, p)
+
+    where `p` is a vector of length `n` and `lse` is a LogExpFunction object.
+
+    This implementation safeguards against numerical under/overflow:
+
+    https://github.com/baggepinnen/MonteCarloMeasurements.jl/blob/4f9b688d298157dc24a5b0a518d971221fbe15dd/src/resampling.jl#L10
+"""
+function obj!(lse::LogSumExp, p)
+    @unpack g = lse
+    maxval, maxind = findmax(p)
+    @. g = q * exp(p - maxval)
+    Σ = sum_all_but(g, maxind) # Σ = ∑gₑ-1
+    f = log1p(Σ) + maxval
+    @. g = g / (Σ + 1)
+    return f
+end
+
+"""
+Get the gradient of logΣexp at the point `p` where
+the `lse` objective was last evaluated:
+
+    g = grad(lse)
+"""
+grad(lse::LogSumExp) = lse.g
+
+"""
+Get the Hessian of logΣexp at the point `p` where
+the `lse` objective was last evaluated:
+
+    H = hess(lse)
+"""
+function hess(lse::LogSumExp)
+    g = lse.g
+    return Diagonal(g) - g * g'
+end
+
+"""
+Special all-but-i sum used by logΣexp.
+"""
+function sum_all_but(w, i)
+    w[i] -= 1
+    s = sum(w)
+    w[i] += 1
+    return s
+end

--- a/src/general-constrained-model/regularizers/regularizer.jl
+++ b/src/general-constrained-model/regularizers/regularizer.jl
@@ -1,0 +1,7 @@
+"""
+    An instance of this class will be used by the CLSModel when solving the system
+    
+    An inheriter of this abstract class must implement:
+
+"""
+abstract type Regularizer end

--- a/src/general-constrained-model/regularizers/sumlogcosh.jl
+++ b/src/general-constrained-model/regularizers/sumlogcosh.jl
@@ -1,0 +1,60 @@
+"""
+    Regularizer used to constrain domain to infty-norm ball
+
+    f(x) = ∑ log(2cosh(x_i))
+"""
+struct SumLogCosh{T<:AbstractFloat, V<:AbstractVector{T}} <: Regularizer
+    g::V      # buffer for gradient
+end
+
+"""
+    Evaluate sum_logcosh, its gradient, and Hessian at `p`:
+
+        f = obj!(slc, p)
+
+    where `p` is a vector of length `n` and `slc` is a `SumLogCosh` object.
+
+    This implementation safeguards against numerical under/overflow.
+"""
+function obj!(slc::SumLogCosh, p)
+    @unpack g = slc
+    # Compute the objective function value
+    f = sum(logcosh_stable.(p))
+    # Compute the gradient
+    @. g = tanh(p)
+    return f
+end
+
+"""
+    Numerically stable computation of log(2cosh(x))
+"""
+function logcosh_stable(x)
+    if abs(x) <= 20.0
+        return log(2cosh(x))
+    else
+        # For large x, log(2cosh(x)) ≈ abs(x) + log(1 + e^{-2abs(x)})
+        # Since e^{-2abs(x)} is negligible, we can approximate log(1 + e^{-2abs(x)}) ≈ 0
+        return abs(x)
+    end
+end
+
+"""
+    Get the gradient of sum_logcosh at the point `p` where
+    the `slc` objective was last evaluated:
+
+        g = grad(slc)
+"""
+grad(slc::SumLogCosh) = slc.g
+
+"""
+    Get the Hessian of sum_logcosh at the point `p` where
+    the `slc` objective was last evaluated:
+
+        H = hess(slc)
+"""
+function hess(slc::SumLogCosh)
+    @unpack g = slc
+    # Compute the Hessian diagonal elements
+    h = @. 1 - g^2  # sech^2(p_i) = 1 - tanh^2(p_i)
+    return Diagonal(h)
+end

--- a/src/general-constrained-model/solver.jl
+++ b/src/general-constrained-model/solver.jl
@@ -1,0 +1,171 @@
+"""
+Dual objective:
+
+    f(y) = λreg(A'y / λ) + 0.5 y∙Cy - b∙y
+
+"""
+function dObj!(cls::CLSModel, y)
+    @unpack A, b, λ, C, reg, w = cls 
+    increment!(cls, :neval_jtprod)
+    w .= 0  # Reset buffer
+    mul!(w, A', y ./ λ)  # w = A' * (y / λ)
+    g = obj!(reg, w)
+    return λ * g + 0.5 * dot(y, C * y) - dot(b, y)
+end
+
+NLPModels.obj(cls::CLSModel, y) = dObj!(cls, y)
+
+"""
+Dual objective gradient
+
+   ∇f(y) = A∇reg(A'y / λ) + Cy - b 
+
+evaluated at `y`. Assumes that the objective was last evaluated at the same point `y`.
+"""
+function dGrad!(cls::CLSModel, y, ∇f)
+    @unpack A, b, λ, C, reg = cls
+    increment!(cls, :neval_jprod)
+    p = grad(reg)
+    ∇f .= -b
+    mul!(∇f, C, y, 1, 1)
+    mul!(∇f, A, p, 1, 1)
+    return ∇f
+end
+
+NLPModels.grad!(cls::CLSModel, y, ∇f) = dGrad!(cls, y, ∇f)
+
+"""
+Dual objective hessian
+
+   ∇²f(y) = (1/λ)A∇²reg(A'y / λ)A' + C
+
+evaluated at `y`. Assumes that the objective was last evaluated at the same point `y`.
+"""
+function dHess(cls::CLSModel)
+    @unpack A, λ, C, reg = cls
+    H = hess(reg)
+    return (A*H*A') ./ λ + C
+end
+
+"""
+    dHess_prod!(cls::CLSModel{T}, z, v) where T
+
+Product of the dual objective Hessian with a vector `z`
+
+    v ← ∇²d(y)z = (1/λ)A∇²reg(A'y / λ)A'z + Cz
+
+where `y` is the point at which the objective was last evaluated.
+"""
+function dHess_prod!(cls::CLSModel, z, Hz)
+    @unpack A, λ, C, w, reg = cls
+    increment!(cls, :neval_jprod)
+    increment!(cls, :neval_jtprod)
+    H = hess(reg)
+    mul!(w, A', z)                 # w = A'z
+    mul!(w, H, w)                  # w = ∇²reg(A'y / λ)(A'z)
+    mul!(Hz, A, w, 1 / λ, 0)       # v = (1/λ)A∇²reg(A'y / λ)A'z
+    mul!(Hz, C, z, 1, 1)           # v += Cz
+    return Hz
+end
+
+function NLPModels.hprod!(cls::CLSModel{T}, ::AbstractVector, z::AbstractVector, Hz::AbstractVector; obj_weight::Real=one(T)) where T
+    return Hz = dHess_prod!(cls, z, Hz)
+end
+
+function solve!(cls::CLSModel{T}; logging=0, monotone=true, max_time::Float64=30.0, kwargs...) where T
+   
+    # Reset counters
+    reset!(cls)    
+
+    # Tracer
+    tracer = DataFrame(iter=Int[], dual_obj=Float64[], r=Float64[], Δ=Float64[], Δₐ_Δₚ=Float64[], cgits=Int[], cgmsg=String[])
+    
+    # Callback routine
+    cb(nlp, solver, stats) = callback(
+    cls, solver, M, stats, tracer, logging, max_time; kwargs...
+    )
+    
+    # Call the Trunk solver
+    trunk_stats = trunk(cls; callback=cb, atol=zero(T), rtol=zero(T), max_time=max_time, monotone=monotone) 
+    
+    stats = ExecutionStats(
+        trunk_stats.status,
+        trunk_stats.elapsed_time,           # elapsed time
+        trunk_stats.iter,                   # number of iterations
+        neval_jprod(cls),                   # number of products with A
+        neval_jtprod(cls),                  # number of products with A'
+        zero(T),                            # TODO: primal objective
+        trunk_stats.objective,              # dual objective
+        (cls.scale).*grad(cls.reg),         # primal solultion `x`
+        (cls.λ).*(trunk_stats.solution),    # residual r = λy
+        trunk_stats.dual_feas,              # norm of the gradient of the dual objective
+        tracer
+    )
+end
+
+function callback(
+    cls::CLSModel{T},
+    solver,
+    M,
+    trunk_stats,
+    tracer,
+    logging,
+    max_time;
+    atol::T = √eps(T),
+    rtol::T = √eps(T),
+    max_iter::Int = typemax(Int),
+    trace::Bool = false,
+    ) where T
+    
+    dObj = trunk_stats.objective 
+    iter = trunk_stats.iter
+    r = trunk_stats.dual_feas # = ||∇ dual obj(x)|| = ||λy||
+    # r = norm(solver.gx)
+    Δ = solver.tr.radius
+    actual_to_predicted = solver.tr.ratio
+    cgits = solver.subsolver.stats.niter
+    cgexit = cg_msg[solver.subsolver.stats.status]
+    ε = atol + rtol * cls.bNrm
+    
+    # Test exit conditions
+    tired = iter >= max_iter
+    optimal = r < ε 
+    done = tired || optimal
+    
+    log_items = (iter, dObj, r, Δ, actual_to_predicted, cgits, cgexit) 
+    trace && push!(tracer, log_items)
+    if logging > 0 && iter == 0
+        println("\n", cls)
+        println("Solver parameters:")
+        @printf("   atol = %7.1e  max time (sec) = %7d\n", atol, max_time)
+        @printf("   rtol = %7.1e  target ∥r∥<ε   = %7.1e\n\n", rtol, ε)
+        @printf("%7s  %9s  %9s  %9s  %9s  %6s  %10s\n",
+        "iter","dual Obj","∥∇dObj∥","Δ","Δₐ/Δₚ","cg its","cg msg")
+    end
+    if logging > 0 && (mod(iter, logging) == 0 || done)
+        @printf("%7d  %9.2e  %9.2e  %9.1e %9.1e  %6d   %10s\n", (log_items...))
+    end
+    
+    if optimal
+        trunk_stats.status = :optimal
+    elseif tired
+        trunk_stats.status = :max_iter
+    end
+    if trunk_stats.status == :unknown
+        return
+    end
+    
+    # Update the preconditioner
+    update!(M)
+end
+
+const cg_msg = Dict(
+"on trust-region boundary" => "⊕",
+"nonpositive curvature detected" => "neg curv",
+"solution good enough given atol and rtol" => "✓",
+"zero curvature detected" => "zer curv",
+"maximum number of iterations exceeded" => "⤒",
+"user-requested exit" => "user exit",
+"time limit exceeded" => "time exit",
+"unknown" => ""
+)

--- a/src/newtoncg.jl
+++ b/src/newtoncg.jl
@@ -13,7 +13,7 @@ end
 Dual objective:
 
 - base case (no scaling, unweighted 2-norm):
-    f(y) = log∑exp(A'y - c) - 0.5λ y∙Cy - b∙y
+    f(y) = log∑exp(A'y - c) + 0.5λ y∙Cy - b∙y
 
 - with scaling and weighted 2-norm:
     f(y) = τ log∑exp(A'y - c) - τ log τ + 0.5λ y∙Cy - b∙y
@@ -169,7 +169,7 @@ function callback(
     elseif tired
         trunk_stats.status = :max_iter
     end
-    if trunk_stats.status == :unkown
+    if trunk_stats.status == :unknown
         return
     end
     


### PR DESCRIPTION
# Implements CLSModel, regularizers and solver
This commit adds the required classes to expand the method to constraints other than simplex. To achieve this, it adds 3 main components. 
## Components
### CLSModel (Constrained Least Squares Model)
This struct is similar to [KLLSModel](https://github.com/MPF-Optimization-Laboratory/KLLS.jl/blob/main/src/model.jl), it is the main object to use in the optimization and inherits `AbstractNLPModel`.

https://github.com/MPF-Optimization-Laboratory/KLLS.jl/blob/dd44d3536cc1ec7d9caa4db2839caa8a04908af9/src/general-constrained-model/CLS-model.jl#L20

### Regularizers
These are constrained specific regularizers, they all inherit from an abstract type `Regularizer`. 

They all implement 3 methods, `obj!`, `grad`, `hess`, that respectively calculates the objective and fills the buffers, calculates the gradient from the same point as last `obj!`call, and calculates the hessian from the same point as last `obj!`call. 

The currently implemented regularizers are:
- LogSumExp to constrain to Simplex
- LogSumCosh to constrain to 1-norm ball
- SumLogCosh to constrain to $\infty$-norm ball

https://github.com/MPF-Optimization-Laboratory/KLLS.jl/blob/dd44d3536cc1ec7d9caa4db2839caa8a04908af9/src/general-constrained-model/regularizers/regularizer.jl#L7

### Solver
The solver is highly similar to the existing KLLS solver, with a few adjustments to accomodate for the replacable regularizers.

https://github.com/MPF-Optimization-Laboratory/KLLS.jl/blob/dd44d3536cc1ec7d9caa4db2839caa8a04908af9/src/general-constrained-model/solver.jl#L75

## Note
In KLLS, the regularizer $\lambda$ is attributed to the least squares term, while this feature is implemented with keeping $\lambda$ to the regularizer, i.e
- KLLS Problem:
$$\min_{y\in \mathbb{R}^m} \frac{\lambda}{2}\|y\|^2  - b^Ty + \text{reg}(A^Ty) \iff \min_{x\in \mathbb{R^n}} \frac{1}{2\lambda}\|Ax -b\|^2 + \text{reg}^*(x)$$

- CLS Problem:
$$\min_{y\in \mathbb{R}^m} \frac{1}{2}\|y\|^2  - b^Ty + \lambda\text{reg}(A^Ty/\lambda) \iff \min_{x\in \mathbb{R^n}} \frac{1}{2}\|Ax -b\|^2 + \lambda \text{reg}^*(x)$$

## TODO
- [ ] Implement tests to check that all the grads and hessians are implemented correctly
- [ ] Implement end to end test to check if the solver works as expected
- [ ] Add missing features such as prior, preconditioning, scaling etc.