### PR TITLE
Optimized the OT linear operator to work faster with CUDA

### DIFF
--- a/src/optimal-transport.jl
+++ b/src/optimal-transport.jl
@@ -69,11 +69,8 @@ function row_col_sum_operator(m::Int, n::Int)
         A(x) = [sum over rows; sum over columns], x reshaped as X = reshape(x, m, n)
     """
     function Afun!(y::AbstractVector{T}, x::AbstractVector{T}, α, β) where T
-        @assert length(x) == N "Input vector x must have length m * n"
-        @assert length(y) == M "Output vector y must have length m + n"
-
-        if β == zero(T)
-            y .= zero(T)
+        if β == 0
+            fill!(y, zero(T))
         else
             y .*= β
         end
@@ -102,11 +99,8 @@ function row_col_sum_operator(m::Int, n::Int)
     end
 
     function _Atfun!(x::AbstractVector{T}, y::AbstractVector{T}, α::T, β::T) where T
-        @assert length(x) == N "Output vector x must have length m * n"
-        @assert length(y) == M "Input vector y must have length m + n"
-
-        if β == zero(T)
-            x .= zero(T)
+        if β == 0
+            fill!(x, zero(T))
         else
             x .*= β
         end


### PR DESCRIPTION
## Optimize OT linear operator

Switched the OT linear operator to use mat-vec multiplications instead of additions.

The $A^\top$ operator uses the BLAS submodule of LinearAlgebra, which gives efficient rank 1 updates to matrices with the `BLAS.ger!` function. This function requires all inputs to be of the same type, hence we need some type conversion logic to make it work. 

### Testing

Tested manually using the script in `./test/optimal-transport.jl`.