### PR TITLE
Add warm start to sequential scale

### DIFF
--- a/src/KLLS.jl
+++ b/src/KLLS.jl
@@ -15,7 +15,7 @@ import SciMLBase: ReturnCode
 
 export KLLSModel, SSModel, OTModel, LPModel
 export NewtonEQ, TrunkLS, SequentialSolve
-export solve!, scale!, regularize!, histogram, maximize!, reset!
+export solve!, scale!, regularize!, histogram, maximize!, reset!, update_y0!
 
 DEFAULT_PRECISION(T) = (eps(T))^(1/3)
 

--- a/src/klls-model.jl
+++ b/src/klls-model.jl
@@ -57,6 +57,10 @@ function scale!(kl::KLLSModel{T}, scale::T) where T
     return kl
 end
 
+function update_y0!(kl::KLLSModel{T}, y0::AbstractVector{T}) where T
+    kl.meta = NLPModelMeta(kl.meta, x0=y0)
+end
+
 function NLPModels.reset!(kl::KLLSModel)
     for f in fieldnames(Counters)
       setfield!(kl.counters, f, 0)

--- a/src/newtoncg.jl
+++ b/src/newtoncg.jl
@@ -119,7 +119,7 @@ function solve!(
         neval_jtprod(kl),               # number of products with A'
         zero(T),                        # TODO: primal objective
         trunk_stats.objective,          # dual objective
-        (kl.scale).*grad(kl.lse),       # primal solultion `x`
+        (kl.scale).*grad(kl.lse),       # primal solution `x`
         (kl.λ).*(trunk_stats.solution), # residual r = λy
         trunk_stats.dual_feas,          # norm of the gradient of the dual objective
         tracer

--- a/src/selfscale.jl
+++ b/src/selfscale.jl
@@ -114,9 +114,9 @@ function solve!(
         neval_jtprod(kl),            # count products with A'
         zero(T),                     # TODO: primal objective
         trunk_stats.objective,       # dual objective
-        x,                           # primal solultion `x`
+        x,                           # primal solution `x`
         (kl.λ)*y,                    # residual r = λy
-        optimality,       # norm of the gradient of the dual objective
+        optimality,                  # norm of the gradient of the dual objective
         tracer                       # TODO: tracer 
     )
     return stats

--- a/test/test-klls-model.jl
+++ b/test/test-klls-model.jl
@@ -21,6 +21,8 @@ end
     A = randn(m, n)
     b = randn(m)
     data = KLLSModel(A, b)
+
+    # Test scaling
     @test try
         scale!(data, 0.5)
         true
@@ -28,6 +30,8 @@ end
         false
     end
     @test data.scale == 0.5
+
+    # Test regularization
     @test try
         regularize!(data, 1e-3)
         true
@@ -35,4 +39,15 @@ end
         false
     end
     @test data.λ == 1e-3
+
+    # Test initial guess update
+    y0 = ones(Float64, m)
+    @test try
+        update_y0!(data, y0)
+        true
+    catch
+        false
+    end
+    @test data.meta.x0 == y0
+    
 end


### PR DESCRIPTION
Currently, when we are solving the iterations of SequentialScale method, we are solving the problem from `y0=zeros(m)`, we should instead use the information from the previous iteration. This PR uses the projection

$$ \tilde{x_i} = x_i \frac{t_{\text{new}}}{t_{\text{old}}} $$

where $x_i$ is the solution of the old problem, and $\tilde{x}_i$ is out starting point for the next problem (radial projection?). This accounts to using the same $y_i$ as the last solution, since they store a notion of the ratio of probabilities anyways (derived this formally) 

## Testing
Tested the new model function in a test, rest are tested in already existing tests