### PR TITLE
🐛 fix: report a real termination status from SequentialSolve (v0.1.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.1.6] - 2026-08-08
+
+### Fixed
+- `SequentialSolve` reported `status = :unknown` for essentially every successful solve. The
+  status was derived from the root finder's `:x_converged` flag alone, but `Roots` reports
+  `:f_converged` in most cases (and also `:exact_zero` / `:converged`). The status now
+  defers to the inner trust-region solve, which tests the criterion that actually governs
+  the returned solution, `‖∇d(y)‖ < atol + rtol‖b‖`, and reports `:stalled` when the root
+  find genuinely fails.
+- Infeasibility detection for `LPModel`. It relabels a solve as `:infeasible` only when the
+  status is `:optimal` and the residual is large, so the bug above meant it could never
+  fire. This was previously marked as a known-broken test.
+
 ## [0.1.5] - 2026-08-05
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DualPerspective"
 uuid = "a1edf54d-33cf-4bd3-8f57-70bdaf668f08"
 authors = ["Michael P. Friedlander <michael.friedlander@ubc.ca> and contributors"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/pypi/src/DualPerspective/juliapkg.json
+++ b/pypi/src/DualPerspective/juliapkg.json
@@ -3,7 +3,7 @@
     "packages": {
         "DualPerspective": {
             "uuid": "a1edf54d-33cf-4bd3-8f57-70bdaf668f08",
-            "version": "=0.1.5"
+            "version": "=0.1.6"
         }
     }
 }

--- a/src/sequential-scale.jl
+++ b/src/sequential-scale.jl
@@ -28,6 +28,30 @@ function value!(kl::DPModel{T}, τ; prods=[0, 0], kwargs...) where T
 end
 
 struct SequentialSolve end
+
+"""
+Root-finder outcomes that count as success. `Roots` distinguishes several: `:x_converged`
+when the bracket on `t` is tight enough, `:f_converged` when the residual is small,
+`:exact_zero` on a hit, and the generic `:converged`. Recognizing only `:x_converged`
+reported almost every successful solve as `:unknown`.
+"""
+const ROOTS_CONVERGED = (:x_converged, :f_converged, :exact_zero, :converged)
+
+"""
+    _sequential_status(tracker, final_run_stats) -> Symbol
+
+Termination status for a sequential-scale solve.
+
+The scale `t` is located by root finding and the solution is then produced by an inner
+trust-region solve. Report failure if the root find did not converge; otherwise defer to
+the inner solve, which tests the criterion that actually governs the returned solution,
+`‖∇d(y)‖ < atol + rtol‖b‖`.
+"""
+function _sequential_status(tracker, final_run_stats)
+    tracker.convergence_flag in ROOTS_CONVERGED || return :stalled
+    return final_run_stats.status
+end
+
 """
     solve!(kl::DPModel, ::SequentialSolve; kwargs...) -> ExecutionStats
 
@@ -106,7 +130,7 @@ function solve!(
     )
 
     stats = ExecutionStats(
-        tracker.convergence_flag == :x_converged ? :optimal : :unknown,
+        _sequential_status(tracker, final_run_stats),
         time() - start_time,                  # elapsed time
         tracker.steps,                 # number of iterations
         prods[1],                      # number of products with A

--- a/test/test-linear-programming.jl
+++ b/test/test-linear-programming.jl
@@ -66,7 +66,10 @@ end
 
     lp = DualPerspective.LPModel(A, b, c, ε=5e-1, λ=5e-1)
     stats = solve!(lp)
-    @test_broken stats.status == :infeasible
+    # Was `@test_broken`: LPModel only relabels to `:infeasible` when the solve reports
+    # `:optimal` (linear-programming.jl:120), and SequentialSolve used to report
+    # `:unknown` for essentially every solve, so the check could never fire.
+    @test stats.status == :infeasible
 
     # model = Model(GLPK.Optimizer)
 

--- a/test/test-sequential-scale.jl
+++ b/test/test-sequential-scale.jl
@@ -26,3 +26,30 @@ using DualPerspective
 
       @test ssSoln.status == :optimal
 end
+
+@testset "SequentialSolve status reflects convergence" begin
+      # The status used to be derived from `tracker.convergence_flag == :x_converged`
+      # alone. Roots far more often reports `:f_converged`, so successful solves came back
+      # as `:unknown`. A single problem can pass that by luck, so sweep a few.
+      Random.seed!(1234)
+      for (m, n) in ((10, 5), (50, 100), (8, 10)), λ in (1e-2, 1e-3, 1e-5)
+            kl = DualPerspective.randDPModel(m, n; λ=λ)
+            stats = solve!(kl, SequentialSolve(); t=sum(kl.q))
+            @test stats.status == :optimal
+            # The status must agree with the criterion the inner solve actually applies.
+            @test stats.optimality < 1e-6 + 1e-6 * kl.bNrm
+      end
+end
+
+@testset "SequentialSolve status mapping" begin
+      # Every Roots success flag must be accepted, and the inner solve's own status passed
+      # through rather than overwritten.
+      inner(status) = (; status=status)
+      for flag in DualPerspective.ROOTS_CONVERGED
+            @test DualPerspective._sequential_status((; convergence_flag=flag), inner(:optimal)) == :optimal
+            @test DualPerspective._sequential_status((; convergence_flag=flag), inner(:max_iter)) == :max_iter
+      end
+      for flag in (:not_converged, :nan, :inf, :algorithm_not_run)
+            @test DualPerspective._sequential_status((; convergence_flag=flag), inner(:optimal)) == :stalled
+      end
+end


### PR DESCRIPTION
## The bug

`SequentialSolve` reported `status = :unknown` for essentially every successful solve:

```
m=10  n=5    λ=1e-3   status=unknown   optimality=6.74e-9
m=50  n=100  λ=1e-3   status=unknown   optimality=2.82e-8
m=8   n=10   λ=1e-5   status=unknown   optimality=6.23e-11
```

The status came from `tracker.convergence_flag == :x_converged ? :optimal : :unknown`. But
`Roots` has four distinct success flags, and reports `:f_converged` — the residual is small —
in most cases. Only 2 of 15 sampled problems reported `:optimal`, despite all fifteen
converging to 1e-8 or better.

## The fix

Accept every Roots success flag (`:x_converged`, `:f_converged`, `:exact_zero`,
`:converged`); otherwise report `:stalled`. When the root find *did* converge, defer to the
inner trust-region solve rather than hardcoding `:optimal` — that solve already tests the
criterion which actually governs the returned solution, `‖∇d(y)‖ < atol + rtol‖b‖`, so a
`:max_iter` result is no longer silently upgraded.

All 15 sampled problems now report `:optimal`.

## Knock-on fix: LPModel infeasibility detection

`LPModel.solve!` relabels a solve as `:infeasible` only when the status is `:optimal` and the
residual is large (`linear-programming.jl:120`). Since `SequentialSolve` never returned
`:optimal`, that check could never fire — infeasible LPs were silently reported as solved.
The test for it was marked `@test_broken`; it now passes and is a normal `@test`.

## Tests

- `test-sequential-scale.jl` sweeps 9 problem/λ combinations, asserting both `:optimal` and
  that the reported optimality meets the solver's own tolerance. The previous single-case
  assertion passed only because that one seed happened to hit `:x_converged`.
- A direct unit test of the status mapping covers every Roots success flag and each failure
  flag, and checks that the inner status is passed through rather than overwritten.

## Verification

Full suite green on Julia 1.10 and 1.12 against a fresh resolve.

## Release

Version bumped to 0.1.6, and the Python wheel's `juliapkg.json` pin moved to `=0.1.6` so
PyPI 0.2.0 ships against this. Publish the wheel only after 0.1.6 registers in General.
