### PR TITLE
🔧 chore: bump python package to 0.2.1 (pins Julia v0.1.6)

### DIFF
--- a/pypi/pyproject.toml
+++ b/pypi/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "DualPerspective"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     { name = "Michael P. Friedlander", email = "michael.friedlander@ubc.ca" },
 ]


### PR DESCRIPTION
## Why

`py-v0.2.0` was tagged at commit `30b2655` — the v0.1.5 merge — and published to PyPI at
00:12 UTC, before v0.1.6 existed. The released wheel therefore pins `=0.1.5`:

```json
{"packages": {"DualPerspective": {"version": "=0.1.5"}}}
```

That install works — users get the `reset!` fix — but not the v0.1.6 SequentialSolve status
fix, so `Solution.status` still comes back `'unknown'` on successful solves. PyPI does not
allow replacing a released version, so the corrected pin ships as 0.2.1.

## What

Only the version number. The `=0.1.6` pin is already on `main` from #31; the sole diff
between the published tag and `main` under `pypi/` was that one line.

## Verified

Built the wheel, installed it into a clean venv with an empty `JULIA_DEPOT_PATH` and no dev
override, so juliapkg resolved the pin from the registry:

```
python: 0.2.1 | julia: 0.1.6
Solution(status='optimal', n=40, iterations=5, optimality=1.463e-12, elapsed_time=1.192s)
```

`status='optimal'` — which is the whole point of the bump.

## Release

After merge: `git tag py-v0.2.1 && git push origin py-v0.2.1`. v0.1.6 is already registered
and propagated, so the pin resolves immediately.